### PR TITLE
fix: remove space after word on double click

### DIFF
--- a/content.js
+++ b/content.js
@@ -164,8 +164,9 @@ function wordView(e, wordModel) {
 }
 
 function handleDbclick(e) {
-  const word = window.getSelection().toString();
+  const word = window.getSelection().toString().trim();
   if (/^[A-Za-z']+$/.test(word)) {
+
     chrome.runtime.sendMessage({ word }, function (response) {
       wordView(e, response);
     });


### PR DESCRIPTION
Using Google Chrome on the Windows system, when double-clicking a word, there will be a space after the word, which will cause the regular check to fail and the window will not pop up.
![image](https://user-images.githubusercontent.com/38437685/184277063-b08d4b34-5423-4807-b135-074323ac104c.png)

